### PR TITLE
Works on Cloudlab again

### DIFF
--- a/rados_deploy/internal/remoto/modulegenerator.py
+++ b/rados_deploy/internal/remoto/modulegenerator.py
@@ -71,6 +71,7 @@ class ModuleGenerator(object):
     def _is_regular_python(self, name):
         if not self._stl_modules_cache:
             self._stl_modules_cache = list(_generate_stl_libs())
+            self._stl_modules_cache.append('time') # so we are able to import time
         return name in self._stl_modules_cache
 
 

--- a/rados_deploy/internal/remoto/modules/rados/cephfs.py
+++ b/rados_deploy/internal/remoto/modules/rados/cephfs.py
@@ -43,13 +43,13 @@ def start_cephfs(node, connection, ceph_deploypath, path='/mnt/cephfs', use_clie
 
     import time
     for x in range(retries):
-        _, _, exitcode = remoto.process.check(connection, 'sudo {} {}'.format(cmd, path), shell=True)
+        out, err, exitcode = remoto.process.check(connection, 'sudo {} {}'.format(cmd, path), shell=True)
         if exitcode == 0:
             prints('[{}] Succesfully called ceph-fuse (attempt {}/{}) (I/O caching={})'.format(node.hostname, x+1, retries, 'true' if use_client_cache else 'false'))    
             state_ok = True
             break
         else:
-            printw('[{}] Executing ceph-fuse... (attempt {}/{})'.format(node.hostname, x+1, retries))
+            printw('[{}] Executing ceph-fuse... (attempt {}/{})\n output: {}\n error: {}'.format(node.hostname, x+1, retries, out, err))
         time.sleep(1)
     if not state_ok:
         return False

--- a/rados_deploy/internal/remoto/modules/rados/osd.py
+++ b/rados_deploy/internal/remoto/modules/rados/osd.py
@@ -130,7 +130,7 @@ def start_osd_memstore(osd, connection, num_osds, silent):
         return all(x.result() for x in futures)
 
 
-def start_osd_bluestore(ceph_deploypath, osd, num_osds, silent):
+def start_osd_bluestore(ceph_deploypath, osd, num_osds, silent, use_ceph_volume):
     '''Starts a Ceph OSD for bluestore clusters.
     Requires that a key "device_path" is set in the extra_info of the node, which points to a device that will serve as data storage location.
     Args:
@@ -138,11 +138,14 @@ def start_osd_bluestore(ceph_deploypath, osd, num_osds, silent):
         osd (metareserve.Node): Node to start OSD daemon on.
         num_osds (int): Amount of OSD daemons to spawn on local device.
         silent: If set, suppresses debug output.
+        use_ceph_volume: If set, uses 'ceph-volume' instead of 'osd create'
 
     Returns:
         `True` on success, `False` on failure.'''
-    # executors = [Executor('{} -q osd create --data {} {}'.format(ceph_deploypath, osd.extra_info['device_path'].split(',')[x], osd.hostname), **get_subprocess_kwargs(silent)) for x in range(num_osds)]
-    executors = [Executor('ssh {} "yes | sudo ceph-volume lvm batch --osds-per-device {} {}"'.format(osd.hostname, num_osds, osd.extra_info['device_path'].split(',')[x]), **get_subprocess_kwargs(silent)) for x in range(len(osd.extra_info['device_path'].split(',')))]
+    if use_ceph_volume:
+        executors = [Executor('ssh {} "sudo ceph-volume lvm batch --yes --no-auto --osds-per-device {} {}"'.format(osd.hostname, num_osds, osd.extra_info['device_path'].split(',')[x]), **get_subprocess_kwargs(silent)) for x in range(len(osd.extra_info['device_path'].split(',')))]
+    else:
+        executors = [Executor('{} -q osd create --data {} {}'.format(ceph_deploypath, osd.extra_info['device_path'].split(',')[x], osd.hostname), **get_subprocess_kwargs(silent)) for x in range(num_osds)]
     Executor.run_all(executors) 
     return Executor.wait_all(executors, print_on_error=True)
 

--- a/rados_deploy/internal/remoto/modules/rados/osd.py
+++ b/rados_deploy/internal/remoto/modules/rados/osd.py
@@ -11,7 +11,7 @@ Requires:
 
 def stop_osds_memstore(osds, silent):
     '''Completely stops and removes all old running OSDs. Does not return anything.
-    Warning: First, CephFS must be stopped, and seconfly, the Ceph pools must removed, before calling this function.'''
+    Warning: First, CephFS must be stopped, and secondly, the Ceph pools must removed, before calling this function.'''
 
 
     # stopping osds

--- a/rados_deploy/internal/remoto/modules/rados/pool.py
+++ b/rados_deploy/internal/remoto/modules/rados/pool.py
@@ -17,8 +17,8 @@ def destroy_pools(silent):
 def create_pools(placement_groups, silent):
     '''Create ceph pools.'''
     try:
-        subprocess.check_call('sudo ceph osd pool create cephfs_data {}'.format(placement_groups), **get_subprocess_kwargs(silent))
-        subprocess.check_call('sudo ceph osd pool create cephfs_metadata {}'.format(placement_groups), **get_subprocess_kwargs(silent))
+        subprocess.check_call('sudo ceph osd pool create cephfs_data {0} {0}'.format(placement_groups), **get_subprocess_kwargs(silent))
+        subprocess.check_call('sudo ceph osd pool create cephfs_metadata {0} {0}'.format(placement_groups), **get_subprocess_kwargs(silent))
         subprocess.check_call('sudo ceph osd pool set cephfs_data pg_autoscale_mode off', **get_subprocess_kwargs(silent))
         subprocess.check_call('sudo ceph fs new cephfs cephfs_metadata cephfs_data', **get_subprocess_kwargs(silent))
         return True

--- a/rados_deploy/internal/remoto/modules/ssh_install.py
+++ b/rados_deploy/internal/remoto/modules/ssh_install.py
@@ -53,9 +53,10 @@ def install_ssh_keys(hosts, keypair, user, use_sudo=True):
 
     local_ip = ''.join('''{0} {1}\n'''.format(x[3:].replace("-", "."), x) for x in neededinfo)
     with open('{}/hosts'.format(home), mode='a') as f:
-        f.write('127.0.0.1 localhost\n')
+        # f.write('127.0.0.1 localhost\n')
         f.write(local_ip)
-    subprocess.call('sudo cp {}/hosts /etc/hosts'.format(home),shell=True)
+    # subprocess.call('sudo cp {}/hosts /etc/hosts'.format(home),shell=True)
+    subprocess.call('sudo cat {}/hosts >> /etc/hosts'.format(home),shell=True)
 
     # if subprocess.call('sudo vgcreate --force --yes "ceph" "/dev/nvme1n1"',shell=True) != 0:
     #     return False

--- a/rados_deploy/internal/remoto/modules/start/bluestore.py
+++ b/rados_deploy/internal/remoto/modules/start/bluestore.py
@@ -106,7 +106,7 @@ def _merge_kwargs(x, y):
     return z
 
 
-def start_rados_bluestore(reservation_str, mountpoint_path, osd_op_threads, osd_pool_size, osd_max_obj_size, placement_groups, use_client_cache, silent, retries):
+def start_rados_bluestore(reservation_str, mountpoint_path, osd_op_threads, osd_pool_size, osd_max_obj_size, placement_groups, use_client_cache, use_ceph_volume, silent, retries):
     '''Starts a Ceph cluster with RADOS-Arrow support.
     Args:
         reservation_str (str): String representation of a `metareserve.reservation.Reservation`. 
@@ -119,6 +119,7 @@ def start_rados_bluestore(reservation_str, mountpoint_path, osd_op_threads, osd_
         osd_max_obj_size (int): Maximal object size in bytes. Normal=128*1024*1024 (128MB).
         placement_groups (int): Amount of placement groups in Ceph.
         use_client_cache (bool): Toggles using cephFS I/O cache.
+        use_ceph_volume (bool): If set, uses 'ceph-volume' instead of 'osd create'
         silent (bool): If set, prints are less verbose.
         retries (int): Number of retries for potentially failing operations.
 
@@ -223,7 +224,7 @@ def start_rados_bluestore(reservation_str, mountpoint_path, osd_op_threads, osd_
         futures_start_osds = []
         for x in osds:
             num_osds = len([1 for y in x.extra_info['designations'].split(',') if y == Designation.OSD.name.lower()])
-            futures_start_osds.append(executor.submit(start_osd_bluestore, ceph_deploypath, x, num_osds, silent))
+            futures_start_osds.append(executor.submit(start_osd_bluestore, ceph_deploypath, x, num_osds, silent, use_ceph_volume))
         if not all(x.result() for x in futures_start_osds):
             close_wrappers(connectionwrappers)
             return False

--- a/rados_deploy/internal/util/executor.py
+++ b/rados_deploy/internal/util/executor.py
@@ -1,6 +1,8 @@
 import subprocess
 import os
 import threading
+import time
+
 
 class Executor(object):
     '''Object to run subprocess commands in a separate thread. This way, Python can continue operating while interacting  with subprocesses.'''

--- a/rados_deploy/start/bluestore.py
+++ b/rados_deploy/start/bluestore.py
@@ -11,9 +11,9 @@ from rados_deploy.start._internal import _pick_admin as _internal_pick_admin
 from rados_deploy.start._internal import _compute_placement_groups as _internal_compute_placement_groups
 
 
-def _start_rados(remote_connection, module, reservation, mountpoint_path, osd_op_threads, osd_pool_size, osd_max_obj_size, placement_groups, use_client_cache, silent=False, retries=5):
+def _start_rados(remote_connection, module, reservation, mountpoint_path, osd_op_threads, osd_pool_size, osd_max_obj_size, placement_groups, use_client_cache, use_ceph_volume, silent=False, retries=5):
     remote_module = remote_connection.import_module(module)
-    return remote_module.start_rados_bluestore(str(reservation), mountpoint_path, osd_op_threads, osd_pool_size, osd_max_obj_size, placement_groups, use_client_cache, silent, retries)
+    return remote_module.start_rados_bluestore(str(reservation), mountpoint_path, osd_op_threads, osd_pool_size, osd_max_obj_size, placement_groups, use_client_cache, use_ceph_volume, silent, retries)
 
 
 def _generate_module_start(silent=False):
@@ -45,7 +45,7 @@ def _generate_module_start(silent=False):
     return importer.import_full_path(generation_loc)
 
 
-def bluestore(reservation, key_path=None, admin_id=None, connectionwrapper=None, mountpoint_path=defaults.mountpoint_path(), osd_op_threads=defaults.osd_op_threads(), osd_pool_size=defaults.osd_pool_size(), osd_max_obj_size=defaults.osd_max_obj_size(), placement_groups=None, use_client_cache=True, device_path=None, silent=False, retries=defaults.retries()):
+def bluestore(reservation, key_path=None, admin_id=None, connectionwrapper=None, mountpoint_path=defaults.mountpoint_path(), osd_op_threads=defaults.osd_op_threads(), osd_pool_size=defaults.osd_pool_size(), osd_max_obj_size=defaults.osd_max_obj_size(), placement_groups=None, use_client_cache=True, device_path=None, use_ceph_volume=False, silent=False, retries=defaults.retries()):
     '''Boot RADOS-Ceph on an existing reservation, running bluestore.
     Requires either a "device_path" key to be set in the extra info of all OSD nodes, or the "device_path" parameter must be set.
     Should point to device to use with bluestore on all nodes.
@@ -61,6 +61,7 @@ def bluestore(reservation, key_path=None, admin_id=None, connectionwrapper=None,
         placement_groups (optional int): Amount of placement groups in Ceph. If not set, we use the recommended formula `(num osds * 100) / (pool size`, as found here: https://ceph.io/pgcalc/.
         use_client_cache (bool): Toggles using cephFS I/O cache.
         device_path (optional str): If set, overrides the "device_path" extra info for all nodes with given value. Should point to device to use with bluestore on all nodes.
+        use_ceph_volume (bool): If set, uses 'ceph-volume' instead of 'osd create'
         silent (optional bool): If set, we only print errors and critical info. Otherwise, more verbose output.
         retries (optional int): Number of tries we try to perform potentially-crashing operations.
 
@@ -95,7 +96,7 @@ def bluestore(reservation, key_path=None, admin_id=None, connectionwrapper=None,
             ssh_kwargs['IdentityFile'] = key_path
         connectionwrapper = get_wrapper(admin_picked, admin_picked.ip_public, silent=silent, ssh_params=ssh_kwargs)
     rados_module = _generate_module_start()
-    state_ok = _start_rados(connectionwrapper.connection, rados_module, reservation, mountpoint_path, osd_op_threads, osd_pool_size, osd_max_obj_size, placement_groups, use_client_cache, silent=silent, retries=retries)
+    state_ok = _start_rados(connectionwrapper.connection, rados_module, reservation, mountpoint_path, osd_op_threads, osd_pool_size, osd_max_obj_size, placement_groups, use_client_cache, use_ceph_volume, silent=silent, retries=retries)
 
     if local_connections:
         close_wrappers([connectionwrapper])


### PR DESCRIPTION
Main contribution of this pull request: rados-deploy works on Cloudlab again. 

In particular, we resolved the following issues: 
- Instead of overwriting `/etc/hosts`, we now append to it
- We lowered the amount of placement-groups to prevent errors
- We added `import time` in `executor.py`, such that line 61 can run without errors
- We allowed `time` to be imported in the generated file of the modulegenerator
- We made the `ceph-volume` command toggleable, because we need to use different commands for AWS and Cloudlab.

Additionally:
- `start_cephfs` in `cephfs.py` now provides more info on error
- Fixed a typo in `osd.py`
- Small change in the `sudo ceph osd pool create` command in `pool.py`, as this seemed to be more commonly used
- Added more information in `_compute_placement_groups`.

Note: This pull request remains a draft until the changes are tested on AWS